### PR TITLE
Add rel="noreferrer noopener" target="_blank" to Github Link

### DIFF
--- a/client/src/components/About.js
+++ b/client/src/components/About.js
@@ -21,7 +21,7 @@ const About = () => (
       players. It is also backed by MongoDB, Javascript, and many node packages.
       Check out our GitHub to find out more. Thanks for stopping by!
     </p>
-    <a href="https://github.com/bnicp/chronoflix">GitHub Link</a>
+    <a href="https://github.com/bnicp/chronoflix" rel="noreferrer noopener" target="_blank">GitHub Link</a>
   </Container>
 );
 


### PR DESCRIPTION
Added attributes to open a new tab for when the Github Link on the About page is clicked on.